### PR TITLE
vagrantfile cpu & ram setting

### DIFF
--- a/p1/Vagrantfile
+++ b/p1/Vagrantfile
@@ -1,0 +1,96 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  #  config.vm.box = "base"
+  # config.vm.box = "generic/ubuntu2004"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessible to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  config.vm.define "node1" do |node1|
+    node1.vm.hostname = "node1"
+    node1.vm.provider :libvirt do |lv|
+      lv.cpus = 1
+      lv.memory = 512
+      lv.cpu_mode = "host-passthrough"
+    end
+  end
+
+  config.vm.define "node2" do |node2|
+    node2.vm.hostname = "node2"
+    node2.vm.provider :libvirt do |lv|
+      lv.cpus = 1
+      lv.memory = 512
+      lv.cpu_mode = "host-passthrough"
+    end
+  end 
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end


### PR DESCRIPTION
#8 Close

## 1. Vagrant Environment Status
checked the current state of the machines using the Vagrant CLI.

```sh
$ vagrant status
[fog][WARNING] Unrecognized arguments: libvirt_ip_command
[fog][WARNING] Unrecognized arguments: libvirt_ip_command
Current machine states:

node1                     inaccessible (libvirt)
node2                     inaccessible (libvirt)

This environment represents multiple VMs. The VMs are all listed
above with their current state. For more information about a specific
VM, run `vagrant status NAME`.
```

> [!Note]
>  The `inaccessible` status is often a result of permission discrepancies between the user session and the `libvirt` system daemon. I proceeded to verify the status directly via `virsh` to confirm the actual state.

---

## 2. Hypervisor Level Verification (Virsh)
By querying the `libvirt` daemon with root privileges, I confirmed that both nodes are active and running.

```sh
$ sudo virsh status
 Id   Name       State
--------------------------
 1    p1_node2   running
 2    p1_node1   running

```


## 3. Hardware Resource Allocation Check
Detailed inspection was performed to ensure that the CPU and Memory were allocated according to the project requirements (**1 vCPU** and **512MB RAM** per node).


### Node 1 : p1_node1

```sh 
$ sudo virsh dominfo p1_node1
Id:             2
Name:           p1_node1
UUID:           ad29f23b-ac4f-4aad-b8ab-709e070eb46a
OS Type:        hvm
State:          running
CPU(s):         1
CPU time:       35.4s
Max memory:     524288 KiB
Used memory:    524288 KiB
Persistent:     yes
Autostart:      disable
Managed save:   no
Security model: selinux
Security DOI:   0
Security label: system_u:system_r:svirt_t:s0:c321,c1005 (enforcing)
```

### Node 1 : p1_node1

```sh
$ sudo virsh dominfo p1_node2
Id:             1
Name:           p1_node2
UUID:           538f8734-caea-419c-8a7b-11869b8c286e
OS Type:        hvm
State:          running
CPU(s):         1
CPU time:       34.2s
Max memory:     524288 KiB
Used memory:    524288 KiB
Persistent:     yes
Autostart:      disable
Managed save:   no
Security model: selinux
Security DOI:   0
Security label: system_u:system_r:svirt_t:s0:c65,c291 (enforcing)
```