### PR TITLE
static ip Setting

### DIFF
--- a/p1/Vagrantfile
+++ b/p1/Vagrantfile
@@ -68,18 +68,22 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you are using for more
   # information on available options.
 
-  config.vm.define "node1" do |node1|
-    node1.vm.hostname = "node1"
-    node1.vm.provider :libvirt do |lv|
+  config.vm.define "Server" do |sv|
+    sv.vm.hostname = "Server"
+    sv.vm.box = "generic/ubuntu2004"
+    sv.vm.network "private_network", ip: "192.168.56.110"
+    sv.vm.provider :libvirt do |lv|
       lv.cpus = 1
       lv.memory = 512
       lv.cpu_mode = "host-passthrough"
     end
   end
 
-  config.vm.define "node2" do |node2|
-    node2.vm.hostname = "node2"
-    node2.vm.provider :libvirt do |lv|
+  config.vm.define "ServerWorker" do |svw|
+    svw.vm.hostname = "ServerWorker"
+    svw.vm.box = "generic/ubuntu2004"
+    svw.vm.network "private_network", ip: "192.168.56.111"
+    svw.vm.provider :libvirt do |lv|
       lv.cpus = 1
       lv.memory = 512
       lv.cpu_mode = "host-passthrough"


### PR DESCRIPTION
## Infrastructure Setup: Multi-node Network Configuration

### Description
This PR establishes the foundational network infrastructure for the K3s cluster. It defines two virtual machines (Server and Worker) with isolated static networking.

### Key Changes

- **Static IP Provisioning:** Configured `eth1` interfaces for consistent internal routing.
  - `Server`: 192.168.56.110
  - `ServerWorker`: 192.168.56.111
- **Vagrant Optimization:** Cleaned up legacy provider metadata to resolve synchronization issues.

### Verification

```sh
$ vargrant ssh-config
Host Server
  HostName 192.168.121.96
  User vagrant
  Port 22
  UserKnownHostsFile /dev/null
  StrictHostKeyChecking no
  PasswordAuthentication no
  IdentityFile /home/kyoulee/Documents/projects/kyoulee/Inception-of-Things/p1/.vagrant/machines/Server/libvirt/private_key
  IdentitiesOnly yes
  LogLevel FATAL
  PubkeyAcceptedKeyTypes +ssh-rsa
  HostKeyAlgorithms +ssh-rsa

Host ServerWorker
  HostName 192.168.121.127
  User vagrant
  Port 22
  UserKnownHostsFile /dev/null
  StrictHostKeyChecking no
  PasswordAuthentication no
  IdentityFile /home/kyoulee/Documents/projects/kyoulee/Inception-of-Things/p1/.vagrant/machines/ServerWorker/libvirt/private_key
  IdentitiesOnly yes
  LogLevel FATAL
  PubkeyAcceptedKeyTypes +ssh-rsa
  HostKeyAlgorithms +ssh-rsa
```


```sh
$ vargrant ssh Server -c “ip addr show eth1”
[fog][WARNING] Unrecognized arguments: libvirt_ip_command
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:03:cc:18 brd ff:ff:ff:ff:ff:ff
    inet 192.168.56.110/24 brd 192.168.56.255 scope global eth1
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fe03:cc18/64 scope link 
       valid_lft forever preferred_lft forever
```

```sh
$ vargrant ssh ServerWorker -c “ip addr show eth1”
[fog][WARNING] Unrecognized arguments: libvirt_ip_command
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:38:f5:2e brd ff:ff:ff:ff:ff:ff
    inet 192.168.56.111/24 brd 192.168.56.255 scope global eth1
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fe38:f52e/64 scope link 
       valid_lft forever preferred_lft forever
```
