### PR TITLE
k3s token sharing created

### DIFF
--- a/p1/Vagrantfile
+++ b/p1/Vagrantfile
@@ -3,6 +3,7 @@
 
 require 'fileutils'
 
+host_token_path = "/tmp/vagrant/token"
 host_ssh_path = "/tmp/vagrant/v_ssh"
 vagrant_ssh_path = "/v_ssh"
 
@@ -11,6 +12,12 @@ unless File.directory?(host_ssh_path)
   puts "[Host] Creating shared directory: #{host_ssh_path}"
   FileUtils.mkdir_p(host_ssh_path)
   FileUtils.chmod_R(0777, host_ssh_path)
+end
+
+unless File.directory?(host_token_path)
+  puts "[Host] Creating shared directory: #{host_token_path}"
+  FileUtils.mkdir_p(host_token_path)
+  FileUtils.chmod_R(0777, host_token_path)
 end
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
@@ -92,6 +99,7 @@ Vagrant.configure("2") do |config|
     sv.vm.provision "shell", run: "always", inline: "mkdir -p /vagrant /vagrant/confs && chown -R vagrant:vagrant /vagrant"
     sv.vm.provision "file", source: "./confs/vagrant.env", destination: "/vagrant/.env"
     sv.vm.provision "file", source: "./confs/server/config.yaml", destination: "/vagrant/config.yaml"
+    sv.vm.synced_folder host_token_path, "/token", type: "9p", accessmode: "mapped", mount_options: ["version=9p2000.L", "trans=virtio", "access=any"]
     sv.vm.synced_folder host_ssh_path, vagrant_ssh_path, type: "9p", accessmode: "mapped", mount_options: ["version=9p2000.L", "trans=virtio", "access=any"]
     sv.vm.provision "shell", path: "scripts/server.sh"
     sv.vm.provision "shell", path: "scripts/ssh-server.sh"
@@ -109,6 +117,7 @@ Vagrant.configure("2") do |config|
     svw.vm.provision "shell", run: "always", inline: "mkdir -p /vagrant /vagrant/confs && chown -R vagrant:vagrant /vagrant"
     svw.vm.provision "file", source: "./confs/vagrant.env", destination: "/vagrant/.env"
     svw.vm.provision "file", source: "./confs/worker/config.yaml", destination: "/vagrant/config.yaml"
+    svw.vm.synced_folder host_token_path, "/token", type: "9p", accessmode: "mapped", mount_options: ["version=9p2000.L", "trans=virtio", "access=any"]
     svw.vm.synced_folder host_ssh_path, vagrant_ssh_path, type: "9p", accessmode: "mapped", mount_options: ["version=9p2000.L", "trans=virtio", "access=any"]
     svw.vm.provision "shell", path: "scripts/worker.sh"
     svw.vm.provision "shell", path: "scripts/ssh-worker.sh"
@@ -128,6 +137,10 @@ Vagrant.configure("2") do |config|
         if Dir.exist?(host_ssh_path)
           FileUtils.rm_rf(host_ssh_path)
           puts "All VMs are gone. Removed #{host_ssh_path}."
+        end
+        if Dir.exist?(host_token_path)
+          FileUtils.rm_rf(host_token_path)
+          puts "All VMs are gone. Removed #{host_token_path}."
         end
       end
     end

--- a/p1/confs/server/config.yaml
+++ b/p1/confs/server/config.yaml
@@ -1,5 +1,5 @@
 # Master Server Setting
 node-ip: ${K3S_MASTER_IP}
 write-kubeconfig-mode: "644"
-token: ${K3S_TOKEN}
+# token: ${K3S_TOKEN}
 https-listen-port: ${K3S_PORT}

--- a/p1/confs/worker/config.yaml
+++ b/p1/confs/worker/config.yaml
@@ -1,4 +1,4 @@
 # Worker Node 설정
 server: "https://$K3S_MASTER_IP:$K3S_PORT"
 node-ip: "$K3S_WORKER_IP"
-token: "$K3S_TOKEN"
+# token: "$K3S_TOKEN"

--- a/p1/scripts/server.sh
+++ b/p1/scripts/server.sh
@@ -16,6 +16,12 @@ fi
 
 # k3s config
 
+if systemctl is-active --quiet k3s; then
+    echo "K3s server is already running. Skipping installation."
+    systemctl status k3s | grep -E "Active:|Loaded:|Main PID: "
+    exit 0
+fi
+
 SERVER_CONFIG_SRC="/vagrant/config.yaml"
 SERVER_CONFIG_DEST="/etc/rancher/k3s/config.yaml"
 
@@ -36,6 +42,8 @@ fi
 
 echo "Setting up K3s Master with IP: $K3S_MASTER_IP"
 curl -sfL https://get.k3s.io | sh -
+cp /var/lib/rancher/k3s/server/node-token /token/node-token
+echo "Generating Server Token..."
 echo "K3s is up!"
 
 # status log

--- a/p1/scripts/worker.sh
+++ b/p1/scripts/worker.sh
@@ -16,6 +16,12 @@ fi
 
 # k3s confing
 
+if systemctl is-active --quiet k3s-agent; then
+    echo "K3s agent is already running. Skipping installation."
+    systemctl status k3s-agent | grep -E 'Active:|Loaded:|Main PID:'
+    exit 0
+fi
+
 WORKER_CONFIG_SRC="/vagrant/config.yaml"
 WORKER_CONFIG_DEST="/etc/rancher/k3s/config.yaml"
 
@@ -59,6 +65,29 @@ done
 echo "🚀 Master Server is up! Proceeding with installation..."
 
 # install & start k3s 
+
+
+# Loop until the file exists or the maximum retries are reached
+MAX_RETRIES=60
+RETRY_COUNT=0
+WAIT_SECONDS=3
+TOKEN_FILE="/token/node-token"
+
+echo "Waiting for Master's k3s token..."
+
+while [ ! -f "$TOKEN_FILE" ]; do
+    echo "  (Attempt $RETRY_COUNT/$MAX_RETRIES): token not ready yet. Retrying in 2s..."
+    if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+        echo "❌ Timeout reached: Master's token not found. Exiting..."
+        exit 1
+    fi
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    sleep $WAIT_SECONDS
+done
+
+export K3S_TOKEN=$(cat /token/node-token)
+
+echo "Master's public token registered successfully."
 
 echo "Setting up K3s Worker with IP: $K3S_WORKER_IP"
 curl -sfL https://get.k3s.io | sh -s - agent


### PR DESCRIPTION
## Summary
This PR implements automated K3s cluster (Server/Agent) orchestration using Vagrant. It focuses on stable and efficient provisioning.

## Key Features
- **Automated Token Sharing**: Configured automatic `node-token` transfer from Server to Agent via a shared directory, eliminating manual `sudo` intervention.
- **Idempotent Provisioning**: Integrated service health checks (`systemctl is-active`) in shell scripts to prevent redundant installations during `vagrant provision`.

## Verification
- Ran `vagrant up` and confirmed all nodes are `Ready` with `kubectl get nodes`.
- Ran `vagrant provision` and verified that K3s installation is skipped as expected.

```sh
==> Server: Running provisioner: shell...
    Server: Running: inline script
==> Server: Running provisioner: file...
    Server: ./confs/vagrant.env => /vagrant/.env
==> Server: Running provisioner: file...
    Server: ./confs/server/config.yaml => /vagrant/config.yaml
==> Server: Running provisioner: shell...
    Server: Running: /tmp/vagrant-shell20260321-145441-yciqe9.sh
    Server: Start setting env from /vagrant/.env
    Server: K3s server is already running. Skipping installation.
    Server:      Loaded: loaded (/etc/systemd/system/k3s.service; enabled; vendor preset: enabled)
    Server:      Active: active (running) since Sat 2026-03-21 09:57:12 UTC; 11min ago
    Server:    Main PID: 2068 (k3s-server)
==> Server: Running provisioner: shell...
    Server: Running: /tmp/vagrant-shell20260321-145441-ziz0cs.sh
    Server: Start setting env from /vagrant/.env
    Server: Public key exported to /v_ssh/server_id_rsa.pub
==> ServerWorker: Running provisioner: shell...
    ServerWorker: Running: inline script
==> ServerWorker: Running provisioner: file...
    ServerWorker: ./confs/vagrant.env => /vagrant/.env
==> ServerWorker: Running provisioner: file...
    ServerWorker: ./confs/worker/config.yaml => /vagrant/config.yaml
==> ServerWorker: Running provisioner: shell...
    ServerWorker: Running: /tmp/vagrant-shell20260321-145441-xft1tx.sh
    ServerWorker: Start setting env from /vagrant/.env
    ServerWorker: K3s agent is already running. Skipping installation.
    ServerWorker:      Loaded: loaded (/etc/systemd/system/k3s-agent.service; enabled; vendor preset: enabled)
    ServerWorker:      Active: active (running) since Sat 2026-03-21 09:57:33 UTC; 11min ago
    ServerWorker:    Main PID: 2101 (k3s-agent)
==> ServerWorker: Running provisioner: shell...
    ServerWorker: Running: /tmp/vagrant-shell20260321-145441-qotqrw.sh
    ServerWorker: Start setting env from /vagrant/.env
    ServerWorker: Waiting for Master's public key...
    ServerWorker: Master's public key registered successfully.
    ServerWorker: ✅ Provisioning complete.
``